### PR TITLE
Initial draft of security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+Thanks for helping make our software safe for everyone.
+
+## Security
+
+We take the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organization, [Determined-ai](https://github.com/Determined-ai).
+
+## Reporting Security Issues
+
+If you believe you have found a security vulnerability in any of our repositories, please report it to us using [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Send a report via email to [security@determined.ai](security@determined.ai) instead.
+
+In the report, include as much of the information listed below as you can:
+
+  * The type of issue (e.g. buffer overflow, SQL injection, or cross-site scripting)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us better understand the issue, allowing us to triage your report and resolve the issue more efficiently.


### PR DESCRIPTION
This document was largely lifted from
https://github.com/github/.github/edit/master/SECURITY.md, which is
licensed under Creative Commons Zero - a license essentially waiving any
copyright claim from the content, and allowing us to legitimately reuse
it without disclosure. I'm uncomforatble with no credit, so I'm still
citing my source in the git commit message.